### PR TITLE
Upgrade kotest from 4.2.0.RC1 to 4.2.0.RC2

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -6,7 +6,7 @@
 
 plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
 
-version.kotest=4.2.0.RC1
+version.kotest=4.2.0.RC2
 
 version.kotlin=1.3.72
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.