### PR TITLE
Upgrade mockito-core from 3.5.5 to 3.5.6

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -10,4 +10,4 @@ version.kotest=4.2.0
 
 version.kotlin=1.3.72
 
-version.org.mockito..mockito-core=3.5.5
+version.org.mockito..mockito-core=3.5.6


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.