### PR TITLE
Upgrade mockito-core from 3.5.10 to 3.5.11

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -10,4 +10,4 @@ version.kotest=4.2.5
 
 version.kotlin=1.3.72
 
-version.org.mockito..mockito-core=3.5.10
+version.org.mockito..mockito-core=3.5.11


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.