### PR TITLE
Upgrade mockito-core from 3.7.0 to 3.7.7

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -10,4 +10,4 @@ version.kotest=4.3.2
 
 version.kotlin=1.3.72
 
-version.org.mockito..mockito-core=3.7.0
+version.org.mockito..mockito-core=3.7.7


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.