### PR TITLE
Upgrade mockito-core from 3.7.7 to 3.8.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -10,4 +10,4 @@ version.kotest=4.4.1
 
 version.kotlin=1.3.72
 
-version.org.mockito..mockito-core=3.7.7
+version.org.mockito..mockito-core=3.8.0


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.